### PR TITLE
Enable `orders` with `editing` status

### DIFF
--- a/packages/app/src/hooks/useCustomerOrdersList.tsx
+++ b/packages/app/src/hooks/useCustomerOrdersList.tsx
@@ -35,7 +35,9 @@ export function useCustomerOrdersList({ id, settings }: Props): {
       : [
           id,
           {
-            filters: { status_matches_any: 'placed,approved,cancelled' },
+            filters: {
+              status_matches_any: 'placed,approved,editing,cancelled'
+            },
             include: ['billing_address', 'market'],
             sort: ['-created_at'],
             pageNumber,

--- a/packages/app/src/pages/CustomerOrders.tsx
+++ b/packages/app/src/pages/CustomerOrders.tsx
@@ -63,7 +63,7 @@ export function CustomerOrders(): JSX.Element {
           query={{
             filters: {
               customer_id_eq: customerId,
-              status_matches_any: 'placed,approved,cancelled'
+              status_matches_any: 'placed,approved,editing,cancelled'
             },
             include: ['billing_address'],
             sort: ['-updated_at']


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I enable `orders` with `editing` status in orders list overview inside customer detail page and in full orders list inside customer orders page.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
